### PR TITLE
Use a suitable default server URL

### DIFF
--- a/ROC-Client/nuxt.config.js
+++ b/ROC-Client/nuxt.config.js
@@ -50,7 +50,7 @@ export default {
   io: {
     sockets: [{
       name: 'main',
-      url: 'http://YOUR SERVER IP/HOST HERE:3001'
+      url: 'http://localhost:3001'
     }]
   },
   // Axios module configuration: https://go.nuxtjs.dev/config-axios


### PR DESCRIPTION
When setting this up for local development, the server defaults to `http://localhost:3001` and therefore is going to be the most common option here. This change applies it as the default, so it's one less step for someone to do when starting off with this project.